### PR TITLE
[CU-86b5g4ccj] Add nginx proxy timeouts to fix 503 errors

### DIFF
--- a/modules/container_app_ingress/reverse_proxy.conf
+++ b/modules/container_app_ingress/reverse_proxy.conf
@@ -2,5 +2,8 @@ server {
     listen 80;
     location / {
         proxy_pass http://${ip_address}:${port}/;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
     }
 }


### PR DESCRIPTION
## Summary
- Added nginx proxy timeout configurations to resolve 503 timeout errors
- Set proxy_connect_timeout, proxy_send_timeout, and proxy_read_timeout to 300s (5 minutes)

## Problem
Container app was returning 503 errors with message "The server was not able to produce a timely response to your request"

## Solution
Added explicit nginx proxy timeouts to handle longer-running requests from the Cromwell backend

## Changes
- Added `proxy_connect_timeout`: 300s
- Added `proxy_send_timeout`: 300s  
- Added `proxy_read_timeout`: 300s

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>